### PR TITLE
Add `--preserve-symlinks` flag to Node invocation

### DIFF
--- a/src/invoke-lambda/run-in-node.js
+++ b/src/invoke-lambda/run-in-node.js
@@ -9,7 +9,7 @@ module.exports = function runInNode (options, request, timeout, callback) {
     else {
       let minify = script => '"' + script.replace(/\n/g, '').trim() + '"'
       let script = minify(data.toString())
-      spawn('node', [ '-e', script ], options, request, timeout, callback)
+      spawn('node', [ '-e', script, '--preserve-symlinks' ], options, request, timeout, callback)
     }
   })
 }


### PR DESCRIPTION
Potential fix for issue @architect/architect#1059

The move to symlinks for `shared` and `views` has diverged the module handling behaviour of Sandbox from that of a deployed Lambda function. This is because Node/commonjs resolves modules accessed via a symlink before adding them in to the internal module cache. For straight forward module usage directly from `shared` or `views` this works fine, but I have stumbled on an odd edge case where Sandbox throws an error that wouldn't occur in production.

I have created [a repo](https://github.com/andybee/arc-v6-v8-import-issue) that demonstrates the issue between Arc 6 and Arc 8.

To fix this, Node can optionally be run with a flag that changes the module resolution behaviour. When introducing this flag on the demo project above, the problem is resolved.

The only thing that concerns me is this quote from the [Node.js documentation](https://nodejs.org/api/cli.html#cli_preserve_symlinks) for this flag:

> Note, however, that using --preserve-symlinks can have other side effects. Specifically, symbolically linked native modules can fail to load if those are linked from more than one location in the dependency tree (Node.js would see those as two separate modules and would attempt to load the module multiple times, causing an exception to be thrown).
> 
> The --preserve-symlinks flag does not apply to the main module, which allows node --preserve-symlinks node_module/.bin/<foo> to work. To apply the same behavior for the main module, also use --preserve-symlinks-main.

My understanding is that by "native" they mean compiled functions? I think it's unlikely they're commonly used in Architect projects (not least because of the issue between local dev environment CPU architecture/OS and the target Lambda function's), but I'd appreciate someone with more specialist commonjs knowledge than I, who might appreciate more of the nuances with this, to wade in.